### PR TITLE
Fixes for RPM package

### DIFF
--- a/rpm/leofs.spec
+++ b/rpm/leofs.spec
@@ -17,9 +17,12 @@ LeoFS is a highly available, distributed, eventually consistent object/blob stor
 %prep
 echo ${RPM_BUILD_ROOT}
 #%setup -q -n leofs-%{version}
-git clone https://github.com/leo-project/leofs.git ${RPM_BUILD_DIR}
+
+%__rm -rf ${RPM_BUILD_DIR}/leofs.git
+git clone https://github.com/leo-project/leofs.git ${RPM_BUILD_DIR}/leofs.git
 
 %build
+cd leofs.git
 git checkout %{version}
 make
 make release
@@ -27,11 +30,11 @@ make release
 %install
 %__mkdir -p ${RPM_BUILD_ROOT}%{_prefix}/local/leofs/%{version}
 %__mkdir -p ${RPM_BUILD_ROOT}%{_prefix}/local/bin
-%__cp -rp ${RPM_BUILD_DIR}/package/* ${RPM_BUILD_ROOT}%{_prefix}/local/leofs/%{version}
-%__cp -rp ${RPM_BUILD_DIR}/leofs-adm ${RPM_BUILD_ROOT}%{_prefix}/local/bin
+%__cp -rp ${RPM_BUILD_DIR}/leofs.git/package/* ${RPM_BUILD_ROOT}%{_prefix}/local/leofs/%{version}
+%__cp -rp ${RPM_BUILD_DIR}/leofs.git/leofs-adm ${RPM_BUILD_ROOT}%{_prefix}/local/bin
 
 %clean
-%__rm -rf ${RPM_BUILD_DIR}
+%__rm -rf ${RPM_BUILD_DIR}/leofs.git
 %__rm -rf ${RPM_BUILD_ROOT}
 
 %files

--- a/rpm/leofs.spec
+++ b/rpm/leofs.spec
@@ -9,6 +9,11 @@ URL:		http://www.leofs.org/
 Source0:	leofs-%{version}.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Prefix:		%{_prefix}/local/leofs
+BuildRequires:  git
+# for building leo_mcerl/c_src/libcutil
+BuildRequires:  cmake gcc check-devel
+# for building eleveldb/c_src/snappy
+BuildRequires:  gcc-c++ lzo-devel zlib-devel
 #BuildArch:	noarch
 
 %description

--- a/rpm/leofs.spec
+++ b/rpm/leofs.spec
@@ -39,6 +39,7 @@ make release
 %__mkdir -p ${RPM_BUILD_ROOT}%{_prefix}/local/leofs/%{version}
 %__mkdir -p ${RPM_BUILD_ROOT}%{_prefix}/local/bin
 %__cp -rp ${RPM_BUILD_DIR}/leofs.git/package/* ${RPM_BUILD_ROOT}%{_prefix}/local/leofs/%{version}
+%__cp -rp ${RPM_BUILD_DIR}/leofs.git/leofs-adm ${RPM_BUILD_ROOT}%{_prefix}/local/bin
 
 %clean
 %__rm -rf ${RPM_BUILD_DIR}/leofs.git


### PR DESCRIPTION
Obvious build requirement for "erlang" package is still missing (in case non-packaged version is used for building this). If adding it won't create any trouble it makes sense to do that as well, of course.