### PR TITLE
Mark config files so they can't be overwritten or removed if changed

### DIFF
--- a/deb/make_deb.sh
+++ b/deb/make_deb.sh
@@ -186,7 +186,7 @@ binary-arch:	checkroot build
 	mkdir $(installdir)/leo_storage/avs
 	mkdir $(installdir)/leo_gateway/cache
 	cp leofs-adm $(bindir)
-	dpkg-shlibdeps $(installdir)/leo_manager_0/erts-6.3/bin/beam
+	dpkg-shlibdeps $(installdir)/leo_manager_0/erts-*/bin/beam
 	mkdir -p debian/tmp/DEBIAN
 	dh_installdeb -Pdebian/tmp
 	dpkg-gencontrol

--- a/rpm/leofs.spec
+++ b/rpm/leofs.spec
@@ -101,7 +101,10 @@ CURRENT_PERMISSIONS=$(stat -c %a $COOKIE)
 %dir %{target_dir}/leo_manager*
 %{target_dir}/leo_*/bin
 %{target_dir}/leo_*/erts-*
-%{target_dir}/leo_*/etc/*
+%config %{target_dir}/leo_*/etc/*schema
+%config(noreplace) %{target_dir}/leo_*/etc/*.conf
+%config(noreplace) %{target_dir}/leo_*/etc/*.environment
+%config(noreplace) %{target_dir}/leo_gateway/etc/*.pem
 %{target_dir}/leo_*/lib
 %{target_dir}/leo_*/releases
 %{target_dir}/leo_*/snmp

--- a/rpm/leofs.spec
+++ b/rpm/leofs.spec
@@ -101,10 +101,12 @@ CURRENT_PERMISSIONS=$(stat -c %a $COOKIE)
 %dir %{target_dir}/leo_manager*
 %{target_dir}/leo_*/bin
 %{target_dir}/leo_*/erts-*
+%{target_dir}/leo_*/etc/*.d
 %config %{target_dir}/leo_*/etc/*schema
 %config(noreplace) %{target_dir}/leo_*/etc/*.conf
 %config(noreplace) %{target_dir}/leo_*/etc/*.environment
-%config(noreplace) %{target_dir}/leo_gateway/etc/*.pem
+%config(noreplace) %{target_dir}/leo_gateway/etc/server_cert.pem
+%config(noreplace) %{target_dir}/leo_gateway/etc/server_key.pem
 %{target_dir}/leo_*/lib
 %{target_dir}/leo_*/releases
 %{target_dir}/leo_*/snmp


### PR DESCRIPTION
Currently, when you upgrade rpm between the same versions (e.g. 1.3.4 -> 1.3.4-rc4, both of which use `/usr/local/leofs/1.3.4` directory) the config files get overwritten, including all the changes. And when you upgrade between versions (e.g. you had 1.3.3, then installed 1.3.4, then removed 1.3.3 before copying config files to 1.3.4) the old config files are removed as well, with all the changes.

With this change, old config files are kept, but only if they were changed by user (unaltered config files get overwritten / removed just like before). Thus, now you can upgrade 1.3.3 to 1.3.4 (which removes 1.3.3) and *then* copy config files from old version to new one. You were already able to copy work directory before but not config files.

I think that many users will always copy config from some third place or install through config management system like chef or ansible, but in case there are people who copy config files from old directories, this change makes upgrade more user-friendly for them.

This isn't changed for Debian/Ubuntu (conffiles listing), because if it's done, dpkg will always keep old config files, even if they were never changed, and each update will result in all files in `etc` subdirectory being kept over. It's just not designed for the case when each update has config files at different paths and tries to keep them all.

Additionally, small fix for library dependency generator in Debian as current one is broken for Erlang != 17.