### PR TITLE
Systemd services (for distros that support them)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,5 @@ $ cp deb/make_deb.sh {WORK_DIRECTORY}
 $ cd {WORK_DIRECTORY}
 $ sh make_deb.sh {LeoFS's Version} {use systemd}
 ```
-where "use systemd" can be either "yes" for building packages for systemd-compatible distro
-such as Ubuntu 16.04 or "no" for making package that doesn't support (and depends on) systemd.
+where "use systemd" can be either "yes" for building a package for systemd-compatible distro
+such as Ubuntu 16.04 or "no" for making a package that doesn't support (and depends on) systemd.

--- a/README.md
+++ b/README.md
@@ -46,5 +46,7 @@ $ cp deb/make_deb.sh {WORK_DIRECTORY}
 4. Build deb file
 ```bash
 $ cd {WORK_DIRECTORY}
-$ sh make_deb.sh {LeoFS's Version}
+$ sh make_deb.sh {LeoFS's Version} {use systemd}
 ```
+where "use systemd" can be either "yes" for building packages for systemd-compatible distro
+such as Ubuntu 16.04 or "no" for making package that doesn't support (and depends on) systemd.

--- a/common/check_version.sh
+++ b/common/check_version.sh
@@ -1,13 +1,21 @@
 #!/bin/sh
 
-# This script ensures that no one tries to use new version of packaging script (which require leofs >= 1.3.3)
+# This script ensures that no one tries to use new version of packaging script (which require leofs > 1.3.7)
 # with an older version by mistake. The way this check works might become obsolete at some point when original file
 # is moved; it will probably be OK to replace or remove it at that point.
 
+# also checks if epmd is build with systemd support (only when building systemd-compatible package)
+
 continue_anyway=false
 version=$1
-URL="https://raw.githubusercontent.com/leo-project/leofs/$version/rel/common/launch.sh"
+URL="https://raw.githubusercontent.com/leo-project/leofs/$version/rel/service/leofs-epmd.socket"
 tmpfile=$(mktemp)
+
+case "$2" in
+    yes)  systemd_check=yes ;;
+      *)  systemd_check=no  ;;
+esac
+
 
 cleanup () {
     rm -f $tmpfile
@@ -24,7 +32,7 @@ go_on_after_warning () {
 
     echo "Do you want to continue? The resulting package is not likely to work correctly."
     echo "It is recommended that you use older version of packaging scripts instead"
-    echo "(older version is available at https://github.com/leo-project/leofs_package/tree/1.0.0)"
+    echo "(older version is available at https://github.com/leo-project/leofs_package/tree/1.2.0)"
     read -p "Type y to continue: " answer
     case "$answer" in
         y|Y ) echo "Ignoring possible problems, proceed at your own risk!"
@@ -34,6 +42,27 @@ go_on_after_warning () {
     esac
 }
 
+check_epmd_for_systemd() {
+    epmd -help 2>& 1 | grep systemd > /dev/null
+    [ $? -eq 0 ] && return
+
+    echo "You are trying to build package with systemd support using Erlang runtime built"
+    echo "WITHOUT systemd support. This is not supported and will result in broken package,"
+	echo "as package with systemd support depends on \"socket activation\" feature in epmd."
+	echo "Please use Erlang \>= 17 configured with --enable-systemd option."
+    read -p "Type y to continue: " answer
+    case "$answer" in
+        y|Y ) echo "Ignoring possible problems, proceed at your own risk!" ;;
+          * ) echo "Aborting package build!"
+              exit 1 ;;
+    esac
+}
+
+if [ "$systemd_check" = yes ]
+then
+    check_epmd_for_systemd
+fi
+
 if ! which curl > /dev/null
 then
     echo "curl is not installed, unable to proceed with version check"
@@ -42,19 +71,12 @@ fi
 
 curl -s "$URL" -o $tmpfile
 
-# sanity check - whether curl actually has downloaded some shell script
-head -1 $tmpfile | grep bin/sh  > /dev/null
+# sanity check - whether curl actually has downloaded unit file
+head -1 $tmpfile | grep Unit  > /dev/null
 if [ $? -ne 0 ]
 then
     echo "Unable to download file from $URL"
     echo "Version check is impossible!"
-    go_on_after_warning
-fi
-
-grep RUNNER_USER= $tmpfile | grep leofs > /dev/null
-if [ $? -ne 0 ]
-then
-    echo "Source version is too old to build this package with!"
     go_on_after_warning
 fi
 

--- a/common/check_version.sh
+++ b/common/check_version.sh
@@ -32,7 +32,7 @@ go_on_after_warning () {
 
     echo "Do you want to continue? The resulting package is not likely to work correctly."
     echo "It is recommended that you use older version of packaging scripts instead"
-    echo "(older version is available at https://github.com/leo-project/leofs_package/tree/1.2.0)"
+    echo "(older version is available at https://github.com/leo-project/leofs_package/releases/tag/1.2.0)"
     read -p "Type y to continue: " answer
     case "$answer" in
         y|Y ) echo "Ignoring possible problems, proceed at your own risk!"
@@ -48,8 +48,8 @@ check_epmd_for_systemd() {
 
     echo "You are trying to build package with systemd support using Erlang runtime built"
     echo "WITHOUT systemd support. This is not supported and will result in broken package,"
-	echo "as package with systemd support depends on \"socket activation\" feature in epmd."
-	echo "Please use Erlang \>= 17 configured with --enable-systemd option."
+    echo "as package with systemd support depends on \"socket activation\" feature in epmd."
+    echo "Please use Erlang \>= 17 configured with --enable-systemd option."
     read -p "Type y to continue: " answer
     case "$answer" in
         y|Y ) echo "Ignoring possible problems, proceed at your own risk!" ;;

--- a/deb/make_deb.sh
+++ b/deb/make_deb.sh
@@ -158,8 +158,8 @@ EOT
 if [ "$USE_SYSTEMD" = yes ]
 then
     cat << 'EOT' >> debian/leofs.postinst
-# If this is first configured version, or previous configured version was < 1.4.0, reset services state
-        if [ -z "$2" ] || dpkg --compare-versions "$2" lt 1.4.0
+# If this is first configured version, or previous configured version was < 1.3.8, reset services state
+        if [ -z "$2" ] || dpkg --compare-versions "$2" lt 1.3.8
         then
 # preset enables everything by default on Debian/Ubuntu, so it's meaningless to do for the rest of services
             systemctl preset leofs-epmd.socket
@@ -182,6 +182,10 @@ EOT
 if [ "$USE_SYSTEMD" = yes ]
 then
     cat << 'EOT' >> debian/leofs.prerm
+#!/bin/sh
+
+set -e
+
 if [ "$1" = "remove" ]; then
     systemctl --no-reload disable leofs-epmd.service > /dev/null 2>&1 || :
     systemctl stop leofs-epmd.service > /dev/null 2>&1 || :
@@ -204,6 +208,10 @@ fi
 if [ "$USE_SYSTEMD" = yes ]
 then
     cat << 'EOT' >> debian/leofs.postrm
+#!/bin/sh
+
+set -e
+
 if [ "$1" = "remove" ]; then
     systemctl daemon-reload
 fi

--- a/rpm/leofs.spec
+++ b/rpm/leofs.spec
@@ -98,7 +98,7 @@ CURRENT_PERMISSIONS=$(stat -c %a $COOKIE)
 [ "a$CURRENT_OWNER" = aleofs:leofs ] || chown leofs:leofs $COOKIE
 [ "a$CURRENT_PERMISSIONS" = a400 ] || chmod 0400 $COOKIE
 
-%triggerun -- leofs < 1.4.0
+%triggerun -- leofs < 1.3.8
 [ $2 = 0 ] && exit 0; :
 %if %use_systemd
 # Install defaults for systemd services on upgrade from versions without systemd support

--- a/rpm/make_rpm.sh
+++ b/rpm/make_rpm.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env sh
 cd `dirname $0`
 if [ $# -eq 1 ]; then
-  ./check_version.sh ${1} || exit 1
+  rhel_ver=$(rpmbuild --eval='0%{?rhel}' 2>/dev/null)
+  fedora_ver=$(rpmbuild --eval='0%{?fedora}' 2>/dev/null)
+  [ $rhel_ver -ge 7 -o $fedora_ver -ge 18 ] && use_systemd=yes
+
+  ./check_version.sh ${1} ${use_systemd} || exit 1
   sed -e "s/%{ver}/${1}/g" leofs.spec > leofs-${1}.spec
   rpmbuild -bb leofs-${1}.spec
   if [ $? == 0 ]; then
@@ -14,5 +18,5 @@ if [ $# -eq 1 ]; then
   fi
   rm -f leofs-${1}.spec
 else
-  echo Usage: leofs.sh version
+  echo "Usage: $0 <version>"
 fi


### PR DESCRIPTION
Part of https://github.com/leo-project/leofs/issues/790.

The original repo needs to be tagged as 1.2.0 before merging this; version tagged as 1.2.0 should be used for building v1.3.3-1.3.7, and this one only supports versions after 1.3.7 (just the current develop branch right now).

Strictly speaking, right now this version can be used for building 1.3.7 in non-systemd mode, but I plan to do some changes which might break this so it's better to separate them now.