### PR TITLE
More complete dependencies for resulting package

### DIFF
--- a/deb/make_deb.sh
+++ b/deb/make_deb.sh
@@ -57,7 +57,7 @@ Homepage: https://leo-project.net/leofs/
 
 Package: leofs
 Architecture: any
-Depends: ${shlibs:Depends}, sudo,
+Depends: ${shlibs:Depends}, sudo, sysstat, netcat-openbsd,
 EOT
 
 if [ "$USE_SYSTEMD" = yes ]

--- a/rpm/leofs.spec
+++ b/rpm/leofs.spec
@@ -20,7 +20,7 @@ BuildRequires:  gcc-c++ lzo-devel zlib-devel
 BuildRequires: systemd
 %endif
 
-Requires:       sudo
+Requires:       sudo sysstat /usr/bin/nc
 %{?systemd_requires}
 
 #BuildArch:	noarch


### PR DESCRIPTION
Explicit dependencies on sysstat (to provide iostat for disk watchdog) and BSD variant of netcat (for leofs-adm). Netcat dependency is pulled by executable name for RPM because package is named differently on EL6 (nc) and EL7 (nmap-ncat). Need to recommend people who aren't able to install package for the first time with `rpm -i` to use `yum localinstall` instead to pull that dependency.

Fixes https://github.com/leo-project/leofs/issues/519, but, strictly speaking, not in all cases because Debian & Ubuntu allow both "netcat-traditional" and "netcat-openbsd" to be installed and actual implementation of "nc" can be set with alternative to netcat-traditional even in presence of netcat-openbsd package. This isn't likely, but still. Better mention this in installation documentation.