### PR TITLE
Fix errors of making rpm - https://circleci.com/gh/leo-project/leofs/336

### DIFF
--- a/rpm/leofs.spec
+++ b/rpm/leofs.spec
@@ -152,8 +152,7 @@ systemctl start leofs-epmd.socket
 %endif
 
 %files
-%defattr(-,root,root,-)
-%dir %{target_dir}
+%define _unpackaged_files_terminate_build 0
 
 %attr(2755,leofs,leofs) %{target_dir}/leo_storage/avs
 %attr(2755,leofs,leofs) %{target_dir}/leo_gateway/cache


### PR DESCRIPTION
I've tested [LeoFS v1.4.3's CentOS package](https://github.com/leo-project/leofs/releases/download/1.4.3/leofs-1.4.3-1.el7.x86_64.rpm) on our environment whether there are issues.

```
# ./current/leofs-adm status
 [System Confiuration]
-----------------------------------+----------
 Item                              | Value
-----------------------------------+----------
 Basic/Consistency level
-----------------------------------+----------
                    system version | 1.4.3
                        cluster Id | leofs_1
                             DC Id | dc_1
                    Total replicas | 1
          number of successes of R | 1
          number of successes of W | 1
          number of successes of D | 1
 number of rack-awareness replicas | 0
                         ring size | 2^128
-----------------------------------+----------
 Multi DC replication settings
-----------------------------------+----------
 [mdcr] max number of joinable DCs | 2
 [mdcr] total replicas per a DC    | 1
 [mdcr] number of successes of R   | 1
 [mdcr] number of successes of W   | 1
 [mdcr] number of successes of D   | 1
-----------------------------------+----------
 Manager RING hash
-----------------------------------+----------
                 current ring-hash | 433fe365
                previous ring-hash | 433fe365
-----------------------------------+----------

 [State of Node(s)]
-------+--------------------------+--------------+---------+----------------+----------------+----------------------------
 type  |           node           |    state     | rack id |  current ring  |   prev ring    |          updated at
-------+--------------------------+--------------+---------+----------------+----------------+----------------------------
  S    | storage_0@127.0.0.1      | running      |         | 433fe365       | 433fe365       | 2019-03-02 13:51:13 +0000
  G    | gateway_0@127.0.0.1      | running      |         | 433fe365       | 433fe365       | 2019-03-02 13:51:31 +0000
-------+--------------------------+--------------+---------+----------------+----------------+----------------------------
```

We've recognized that this fix has no issue.
